### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+.eslintrc
+.travis.yml


### PR DESCRIPTION
This introduces a npmignore file in order to ignore some resources for the published npm module, specifically the test folder.
