### PR TITLE
chore: add test for non existent file

### DIFF
--- a/test/test_engine_injectjs.js
+++ b/test/test_engine_injectjs.js
@@ -31,4 +31,25 @@ describe('engine', function () {
       });
     });
   });
+
+  it('should return false on non-existent file', function (done) {
+    driver.create({ path: require(process.env.ENGINE || 'phantomjs').path }, function (err, browser) {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      var filePath = '/not/existent';
+
+      browser.injectJs(filePath, function (err, result) {
+
+        if (err) {
+          done(err);
+          return;
+        }
+        assert.equal(result, false);
+        browser.exit(done);
+      });
+    });
+  });
 });


### PR DESCRIPTION
This adds a test for the correct result on an injectJs call with a non-existent file
